### PR TITLE
feat: added arrows to scroll between images

### DIFF
--- a/src/components/image/image.js
+++ b/src/components/image/image.js
@@ -25,6 +25,7 @@ const ImageService = ($mdDialog, $timeout) => {
         vm.keyDown = keyDown;
         vm.nextImage = nextImage;
         vm.prevImage = prevImage;
+        vm.activate_scroll = params.activate_scroll
 
         init();
         $timeout(() => { vm.loaded = true; }, 150);

--- a/src/components/image/image.scss
+++ b/src/components/image/image.scss
@@ -27,6 +27,30 @@
     opacity: .75;
   }
 
+  .dialog__next_img {
+    position: absolute;
+    width: 70px;
+    height: 70px;
+    top: 50%;
+    right: 0;
+    margin: 0;
+    margin-top: -35px;
+    padding: 15px;
+    opacity: .75;
+  }
+
+  .dialog__prev_img {
+    position: absolute;
+    width: 70px;
+    height: 70px;
+    top: 50%;
+    left: 0;
+    margin: 0;
+    margin-top: -35px;
+    padding: 15px;
+    opacity: .75;
+  }
+
   .dialog__image-container {
     position: relative;
     background: black;

--- a/src/components/image/image.tpl.html
+++ b/src/components/image/image.tpl.html
@@ -6,9 +6,15 @@
             layout="row" layout-align="center center"
             ng-swipe-right="nextImage()"
             ng-swipe-left="prevImage()">
-        <md-button class="md-icon-button dialog__close" ng-click="close()">
-          <md-icon>close</md-icon>
-        </md-button>
+            <md-button class="md-icon-button dialog__close" ng-click="close()">
+              <md-icon>close</md-icon>
+            </md-button>
+            <md-button ng-if="activate_scroll && " class="md-icon-button dialog__next_img" ng-click="nextImage()">
+              <md-icon>skip_next</md-icon>
+            </md-button>
+            <md-button ng-if="activate_scroll" class="md-icon-button dialog__prev_img" ng-click="prevImage()">
+              <md-icon>skip_previous</md-icon>
+            </md-button>
         <img load-src="{{ image.thumburlbig }}">
       </div>
       <div class="dialog__image-description"

--- a/src/components/main/monument/monument.html
+++ b/src/components/main/monument/monument.html
@@ -34,7 +34,7 @@
               layout="row"
               layout-align="center center"
               ng-repeat="image in $ctrl.image"
-              ng-click="$ctrl.openImage(image, $event)"
+              ng-click="$ctrl.openImage(image, $event,false)"
             >
               <img load-src="{{image.thumburl}}" />
             </a>
@@ -359,7 +359,7 @@
       <div class="monument__images" ng-if="$ctrl.images && $ctrl.images.length">
         <a
           ng-repeat="image in $ctrl.images"
-          ng-click="$ctrl.openImage(image, $event)"
+          ng-click="$ctrl.openImage(image, $event,$ctrl.images.length>1)"
         >
           <img class="image" ng-src="{{image.thumburl}}" />
         </a>

--- a/src/components/main/monument/monument.js
+++ b/src/components/main/monument/monument.js
@@ -497,11 +497,12 @@ ${getCategory()}
     });
   }
 
-  function openImage(image, event) {
+  function openImage(image, event,activate_scroll) {
     imageService.openImage({
       image,
       event,
       list: vm.images,
+      activate_scroll:activate_scroll,
     });
   }
 


### PR DESCRIPTION
## Add navigation arrows for image carousel

### Description
In order to enhance user experience when navigating between images of a monument, I have added two arrow icons for easier navigation. These icons are linked to the `prevImage()` and `nextImage()` functions. Previously, these functions were only accessible via the keyboard's "left arrow" and "right arrow" keys, which might not have been intuitive for new visitors.

### Changes
- Added two arrow icons for navigation between images.
- Linked the arrow icons to the existing `prevImage()` and `nextImage()` functions.
- Implemented a new `activate_scroll` parameter in the `openImage` function, allowing the arrows to only appear if there are multiple images available. This ensures that the navigation arrows are only displayed when useful.

### Screenshot
Here is a screenshot of the added arrow icons:
![image](https://github.com/user-attachments/assets/dfd83c31-fb14-441d-b446-560b39f905c7)

### Impact
- More intuitive navigation for users, especially for those unfamiliar with keyboard shortcuts.
- The arrows will only be visible when there are multiple images, avoiding unnecessary clutter.

I hope this feature proves helpful in improving the user experience.
